### PR TITLE
chore: change api insecure to false

### DIFF
--- a/roles/traefik_add_service/templates/traefik.j2
+++ b/roles/traefik_add_service/templates/traefik.j2
@@ -49,7 +49,7 @@ job "traefik-{{ hostvars[inventory_hostname]['nomad_dc'] }}" {
  
 [api]
   dashboard = false
-  insecure  = true
+  insecure  = false
  
 # Enable Consul Catalog configuration backend.
 [providers.consulCatalog]

--- a/roles/traefik_service/templates/traefik.j2
+++ b/roles/traefik_service/templates/traefik.j2
@@ -49,7 +49,7 @@ job "traefik-{{ hostvars[inventory_hostname]['nomad_dc'] }}" {
  
 [api]
   dashboard = false
-  insecure  = true
+  insecure  = false
  
 # Enable Consul Catalog configuration backend.
 [providers.consulCatalog]


### PR DESCRIPTION

Change "api insecure" to false.

After testing its behavior, the conclusion is that the endpoints are still accessible.