### PR TITLE
Feat: Add try-me nodes

### DIFF
--- a/hosts_ifca_admin_deploy_example
+++ b/hosts_ifca_admin_deploy_example
@@ -14,6 +14,7 @@ node-ifca-1 ansible_host=172.16.44.109
 node-ifca-gpu-0 ansible_host=172.16.44.103
 node-ifca-gpu-1 ansible_host=172.16.44.120
 node-ifca-gpu-2 ansible_host=172.16.44.85
+node-ifca-tryme-0 ansible_host=172.16.44.86
 node-ifca-traefik ansible_host=193.146.75.208
 
 [consul_servers]
@@ -44,6 +45,8 @@ node-ifca-gpu-0 nomad_dc=ifca-ai4eosc domain=ifca nomad_namespaces=ai4eosc,imagi
 node-ifca-gpu-1 nomad_dc=ifca-ai4eosc domain=ifca nomad_namespaces=ai4eosc,imagine,tutorials
 node-ifca-gpu-2 nomad_dc=ifca-ai4eosc domain=ifca nomad_namespaces=ai4eosc,imagine,tutorials
 
+[nomad_tryme_clients]
+node-ifca-tryme-0
 
 # ---- Volume-docker
 [nomad_volume]

--- a/hosts_ifca_admin_deploy_template
+++ b/hosts_ifca_admin_deploy_template
@@ -35,6 +35,10 @@
   ...
 <gpu_clientN_name> nomad_dc=<nomad_dc_name> domain=<domain> nomad_namespaces=<namespace1,namespace2>
 
+[nomad_tryme_clients]
+<tryme_client1_name>
+  ...
+<tryme_clientN_name>
 
 # ---- Volume-docker
 [nomad_volume]

--- a/hosts_site_admin_join_example
+++ b/hosts_site_admin_join_example
@@ -39,6 +39,7 @@ new-cpu-client nomad_dc=new_nomad_dc domain=new_domain nomad_namespaces=ai4eosc,
 new-gpu-client1 nomad_dc=new_nomad_dc domain=new_domain nomad_namespaces=ai4eosc,imagine
 new-gpu-client2 nomad_dc=my_new_nomad_dc domain=my_new_domain nomad_namespaces=imagine
 
+[new_nomad_tryme_clients]
 
 # ---- Volume-docker
 [nomad_new_volume]

--- a/hosts_site_admin_join_template
+++ b/hosts_site_admin_join_template
@@ -39,6 +39,10 @@
   ...
 <new_gpu_clientN_name> nomad_dc=<new_nomad_dc_name> domain=<new_domain> nomad_namespaces=<namespace1,namespace2>
 
+[new_nomad_tryme_clients]
+<new_tryme_client1_name>
+  ...
+<new_tryme_clientN_name>
 
 # ---- Volume-docker
 [nomad_new_volume]

--- a/roles/consul/tasks/configure_client.yml
+++ b/roles/consul/tasks/configure_client.yml
@@ -15,6 +15,11 @@
     consul_hostname: "{{ consul_dc_name }}-traefik"
   when: ("traefik_master" in groups and inventory_hostname in groups['traefik_master'])
 
+- name: Set tryme name
+  set_fact:
+    consul_hostname: "{{ consul_dc_name }}-tn-cpu-{{ groups['nomad_tryme_clients'].index(inventory_hostname) }}"
+  when: ("nomad_tryme_clients" in groups and inventory_hostname in groups['nomad_tryme_clients'])
+
 - name: Set new CPU clients name
   set_fact:
     consul_hostname: "{{ consul_dc_name }}-wn-cpu-{{ groups['nomad_new_cpu_clients'].index(inventory_hostname) }}"
@@ -30,6 +35,11 @@
   set_fact:
     consul_hostname: "{{ consul_dc_name }}-traefik"
   when: ("traefik_new_master" in groups and inventory_hostname in groups['traefik_new_master'])
+
+- name:  Set new TRY-ME client name
+  set_fact:
+    consul_hostname: "{{ consul_dc_name }}-tn-cpu-{{ groups['new_nomad_tryme_clients'].index(inventory_hostname) }}"
+  when: ("new_nomad_tryme_clients" in groups and inventory_hostname in groups['new_nomad_tryme_clients'])
 
 ## Copy the client configuration file 
 

--- a/roles/nomad/files/getDockerImages.sh
+++ b/roles/nomad/files/getDockerImages.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+docker pull registry.services.ai4os.eu/ai4os/deepaas_ui:latest
+
+# Get API modules
+response=$(curl -s -X 'GET' \
+  'https://api.cloud.ai4eosc.eu/v1/catalog/modules/' \
+  -H 'accept: application/json')
+
+# Check response
+if [ $? -ne 0 ]; then
+  echo "API request error."
+  exit 1
+fi
+
+# Parse response as a list
+items=$(echo "$response" | jq -r '.[]')
+
+# Obtain docker image of each module
+for item in $items; do
+
+  # API request for each module
+  metadata_response=$(curl -s -X 'GET' \
+    "https://api.cloud.ai4eosc.eu/v1/catalog/modules/${item}/metadata" \
+    -H 'accept: application/json')
+
+  # Check response
+  if [ $? -ne 0 ]; then
+    echo "Request for item $item has failed."
+    continue
+  fi
+
+  # Get the value of field docker_registry_repo
+  docker_registry_repo=$(echo "$metadata_response" | jq -r '.sources.docker_registry_repo')
+
+  # Download docker image
+  if [ "$docker_registry_repo" != "null" ]; then	  
+    docker pull "$docker_registry_repo"
+  else
+    echo "Field docker_registry_repo of item $item does not exist."
+  fi
+done
+
+

--- a/roles/nomad/tasks/configure.yml
+++ b/roles/nomad/tasks/configure.yml
@@ -14,6 +14,11 @@
     nomad_hostname: "{{ consul_dc_name }}-traefik"
   when: ("traefik_master" in groups and inventory_hostname in groups['traefik_master'])
  
+- name: Set tryme client name
+  set_fact:
+    nomad_hostname: "{{ consul_dc_name }}-tn-cpu-{{ groups['nomad_tryme_clients'].index(inventory_hostname) }}"
+  when: ("nomad_tryme_clients" in groups and inventory_hostname in groups['nomad_tryme_clients'])
+
 - name: Set servers name
   set_fact:
     nomad_hostname: "{{ consul_dc_name }}-server-{{ groups['nomad_servers'].index(inventory_hostname) }}"
@@ -33,6 +38,11 @@
   set_fact:
     nomad_hostname: "{{ consul_dc_name }}-traefik"
   when: ("traefik_new_master" in groups and inventory_hostname in groups['traefik_new_master'])
+
+- name: Set new tryme name
+  set_fact:
+    nomad_hostname: "{{ consul_dc_name }}-tn-cpu-{{ groups['new_nomad_tryme_clients'].index(inventory_hostname) }}"
+  when: ("new_nomad_tryme_clients" in groups and inventory_hostname in groups['new_nomad_tryme_clients'])
  
 - name: Set new servers name
   set_fact:

--- a/roles/nomad/tasks/copy_tryme_scripts.yml
+++ b/roles/nomad/tasks/copy_tryme_scripts.yml
@@ -1,0 +1,12 @@
+- name: Copy getDockerImages script
+  ansible.builtin.copy:
+    src: getDockerImages.sh
+    dest: /home/ubuntu/getDockerImages.sh
+    owner: "{{ username }}"
+    mode: '777'
+
+- name: Add getDockerImages to crontab
+  ansible.builtin.cron:
+    name: "Download module images"
+    hour: "*/4"
+    job: "/home/ubuntu/getDockerImages.sh"

--- a/roles/nomad/tasks/main.yml
+++ b/roles/nomad/tasks/main.yml
@@ -177,6 +177,13 @@
   include_tasks: run_docuum_job.yml
   when: ("nomad_master" in groups and inventory_hostname in groups["nomad_master"])
 
+
+#Copy try-me script
+- name: "Copy try-me script"
+  include_tasks: copy_tryme_scripts.yml
+  when: ("nomad_tryme_clients" in groups and inventory_hostname in groups["nomad_tryme_clients"]) or
+        ("new_nomad_tryme_clients" in groups and inventory_hostname in groups["new_nomad_tryme_clients"])
+
 # Copy tasks file for roles/test_scripts
 - name: "Copy monitoring scripts"
   include_tasks: copy_monitoring_scripts.yaml

--- a/roles/nomad/templates/nomad_client.j2
+++ b/roles/nomad/templates/nomad_client.j2
@@ -19,14 +19,16 @@ client {
    # list of namespaces supported by each client (those specificed in the hosts file)
    namespace = "{{ nomad_namespaces }}"
 
-{% if ("traefik_master" in groups and inventory_hostname in groups['traefik_master']) or ("traefik_new_master" in groups and inventory_hostname in groups['traefik_new_master']) %}
+{% if ("traefik_master" in groups and inventory_hostname in groups['traefik_master']) or ("traefik_new_master" in groups and inventory_hostname in groups['traefik_new_master'])%}
    # Traefik tags needed for both functionalities: traefik_master in from-scratch deployment and traefik_new_master in joining cluster
    compute = false
    tags = "traefik"
-{% else %}
+{% elif ("nomad_tryme_clients" in groups and inventory_hostname in groups['nomad_tryme_clients']) or ("new_nomad_tryme_clients" in groups and inventory_hostname in groups['new_nomad_tryme_clients'])%}
    # rest of Nomad clients tags needed for both functionalities: in nodes that are not traefik_master nor traefik_new_master
-   compute = true
-   
+   compute = false
+   tags = "tryme"
+{% else %}
+  compute = true
   {% if ("nomad_gpu_clients" in groups and inventory_hostname in groups["nomad_gpu_clients"]) or ("nomad_new_gpu_clients" in groups and inventory_hostname in groups["nomad_new_gpu_clients"]) %}
    # GPU tag for both functionalities: nomad_gpu_clients in from-scratch deployment and nomad_new_gpu_clients in joining cluster
    tags= "gpu"


### PR DESCRIPTION
Add new node type. This kind of node has every docker image used in the different modules of the dashboard marketplace.

The idea is to use this nodes to do deploy "try-me" jobs whitout waiting the docker image to download, giving a fast responsivity when trying modules.