### PR TITLE
added entrypoints for NVIDIA Flare to support Federated Learning

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ jobs:
 
   nomad_test:
     name: Nomad + Consul Roles Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         distro:

--- a/roles/nomad/templates/traefik.j2
+++ b/roles/nomad/templates/traefik.j2
@@ -48,7 +48,13 @@ job "traefik-{{ consul_dc_name }}" {
  
   [entryPoints.traefik]
     address = ":8081"
- 
+  
+  [entryPoints.nvflare_fl]
+    address = ":8002"
+  
+  [entryPoints.nvflare_admin]
+    address = ":8003"
+  
 [api]
   dashboard = false
   insecure  = false


### PR DESCRIPTION
Entrypoints for NVIDIA Flare client-server (8002) and server management (8003) communication.

Multiple NVIDIA Flare servers are possible through the HostSNI rule resolution; i.e.:

```hcl
    network {
      port "server-fl" {
        to = 8002
      }
      port "server-admin" {
        to = 8003
      }
    }

    service {
      name = "${JOB_UUID}-server-fl"
      port = "server-fl"
      tags = [
        "traefik.enable=true",
        "traefik.tcp.routers.${JOB_UUID}-server-fl.tls=true",
        "traefik.tcp.routers.${JOB_UUID}-server-fl.tls.passthrough=true",
        "traefik.tcp.routers.${JOB_UUID}-server-fl.entrypoints=nvflare_fl",
        "traefik.tcp.routers.${JOB_UUID}-server-fl.rule=HostSNI(`${JOB_UUID}-server.${meta.domain}-${BASE_DOMAIN}`)",
      ]
    }

    service {
      name = "${JOB_UUID}-server-admin"
      port = "server-admin"
      tags = [
        "traefik.enable=true",
        "traefik.tcp.routers.${JOB_UUID}-server-admin.tls=true",
        "traefik.tcp.routers.${JOB_UUID}-server-admin.tls.passthrough=true",
        "traefik.tcp.routers.${JOB_UUID}-server-admin.entrypoints=nvflare_admin",
        "traefik.tcp.routers.${JOB_UUID}-server-admin.rule=HostSNI(`${JOB_UUID}-server.${meta.domain}-${BASE_DOMAIN}`)",
      ]
    }
```